### PR TITLE
API endpoint that enables to query custom aggregations has been added…

### DIFF
--- a/pip.ado
+++ b/pip.ado
@@ -264,14 +264,18 @@ qui {
 			noi disp in red "You don't have access to internal servers" _n /* 
 					*/ "You're being redirected to public server"
 			local server "https://pipscoreapiqa.worldbank.org"
+			*local server "http://wzlxqpip01.worldbank.org"
 		}
 		
 	}
 	else {
 		local server "https://pipscoreapiqa.worldbank.org"
+		*local server "http://wzlxqpip01.worldbank.org"
 	}
 		
 	local base             = "`server'/api/v1/pip"	
+	*local base2             = "`server'/api/v1/pip-grp" // to exteract aggregated result 
+	local base2             = "http://wzlxqpip01.worldbank.org/api/v1/pip-grp"
 	return local server    = "`server'"
 	
 	//------------ Check internet connection
@@ -540,7 +544,7 @@ qui {
 		return local query_cv_`f' = "`query_cv'"
 			
 		return local base      = "`base'"
-		
+	
 		*---------- Query
 		if ("`popshare'" == ""){
 			local query = "`query_ys'&`query_ct'&`query_cv'&`query_pl'`query_pp'`query_ds'&format=csv"
@@ -552,7 +556,13 @@ qui {
 		global pip_query = "`query'"
 		
 		*---------- Base + query
-		local queryfull "`base'?`query'"
+		if ("`aggregate'" != ""){
+		    local queryfull "`base2'?`query'"
+		}
+		else{
+		    local queryfull "`base'?`query'"
+		}
+
 		return local queryfull_`f' = "`queryfull'"
 		
 		// --- timer
@@ -595,7 +605,7 @@ qui {
 			} 
 		}
 		
-		pause tefera 1
+		pause tefera 1 check time taken to excute the following processes - to be removed
 		
 		// --- timer
 		if ("`timer'" != "") timer off `i_off'

--- a/pip_clean.ado
+++ b/pip_clean.ado
@@ -181,16 +181,16 @@ if ("`type'" == "1") {
 /*==================================================
               2: for Aggregate requests
 ==================================================*/
-pause tefera - aggregate
-
 if ("`type'" == "2") {
-	*if  ("`region'" != "" & regioncid[1] != "XX") {
-	if  ("`region'" != "") {    
+	if  ("`region'" != "" & region_code != "CUSTOM") {
 		tempvar keep_this
 		gen `keep_this' = 0
 		local region_l = `""`region'""'
 		local region_l: subinstr local region_l " " `"", ""', all
 
+		dis "`region_l'"
+		dis "`keep_this'"
+		
 		replace `keep_this' = 1 if inlist(region_code, `region_l')
 		if lower("`region'") == "all" replace `keep_this' = 1
 		keep if `keep_this' == 1 
@@ -200,7 +200,6 @@ if ("`type'" == "2") {
 	
 	if  ("`year'" == "last") {
 		tempvar maximum_y
-		*bys regioncid: egen `maximum_y' = max(requestyear)
 		bys region_code: egen `maximum_y' = max(requestyear)
 		keep if `maximum_y' ==  requestyear
 	}
@@ -208,7 +207,6 @@ if ("`type'" == "2") {
 	***************************************************
 	* 4. Renaming and labeling
 	***************************************************
-	
 
 	rename region_code regioncode
 	*rename regiontitle region

--- a/pip_info.ado
+++ b/pip_info.ado
@@ -29,12 +29,14 @@ qui {
 	if "`server'" == ""  {
 		local site_name = "api/v1"
 		local server   = "https://pipscoreapiqa.worldbank.org"
+		*local server = "http://wzlxqpip01.worldbank.org"
 		local url = "`server'/`site_name'"
 		return local site_name = "`site_name'"
 		return local url       = "`url'"
 	} 
 	else {
 		local url "https://pipscoreapiqa.worldbank.org/api/v1"
+		*local url "http://wzlxqpip01.worldbank.org/api/v1"
 	}
 	
 	***************************************************

--- a/pip_query.ado
+++ b/pip_query.ado
@@ -169,10 +169,16 @@ quietly {
 		local disp_q = "&fill_gaps=true"
 		
 	}
-	
+/*	to aggregate estimate, the pip-grp endpoint uses group_by parameter
 	if ("`aggregate'" != "") {
 		local year_q = "year=`y_comma'"
 		local disp_q = "&aggregate=true"
+	}
+*/
+
+	if ("`aggregate'" != "") {
+		local year_q = "year=`y_comma'"
+		local disp_q = "&group_by=none"
 	}
 	
 	if ("`wb'" != "") {


### PR DESCRIPTION
Hi Andres,

I have implemented an api endpoint in the ado files that enables to query custom aggregations. Now, all the examples in PIP help file works.  I have one suggestion regarding country and region names, would it be possible to include country and region names in the pip data. I can extract and merge country and regional names via country api endpoint, however, this will make the process more slower (as you know it is very slow right now). So, if we have country and regional names in the pip data file, we can minimize time taken that will take to pull the names via country api endpoint.

I noticed that the average per capita income we get via any of the pip commands is not consistent with povcalnet  result. I am wondering if there is a methodology change calculating mean in the pip. All other estimates are consistence except the mean. 

Best,
Tefera 