### PR TITLE
Usage of povcalnet_format option has been updated

### DIFF
--- a/pip.ado
+++ b/pip.ado
@@ -295,6 +295,16 @@ qui {
 		`iso'                            ///
 		`pause'
 		return add
+		
+		pip_clean 1, year("`year'") `iso' rc(`rc')
+		
+		//========================================================
+		// Convert to povcalnet format
+		//========================================================
+		if ("`povcalnet_format'" != "") {
+			pip_povcalnet_format 1, `pause'
+		}
+		
 		exit
 	}
 	
@@ -459,14 +469,8 @@ qui {
 		// --- timer
 		
 		*---------- Clean data
-		if ("`povcalnet_format'" != "") {
-			pip_povcalnet_format `rtype', year("`year'") `iso' /* 
-			*/ rc(`rc') region(`region') `pause' `wb'	
-		}
-		else { 
-			pip_clean `rtype', year("`year'") `iso' /* 
+		pip_clean `rtype', year("`year'") `iso' /* 
 			*/ rc(`rc') region(`region') `pause' `wb'		
-		}
 		
 		pause after cleaning
 		// --- timer
@@ -518,48 +522,25 @@ qui {
 	local n2disp = min(`c(N)', `n2disp')
 	noi di as res _n "{ul: first `n2disp' observations}"
 	
-	if ("`povcalnet_format'" != "") {
-		if ("`subcommand'" == "wb") {
-			sort  year regioncode
-			noi list region year povertyline headcount mean in 1/`n2disp', /*
-			*/ abbreviate(12)  sepby(year)
-		}
+	if ("`subcommand'" == "wb") {
+		sort reporting_year region_code 
+		noi list region reporting_year poverty_line headcount mean in 1/`n2disp', /*
+		*/ abbreviate(12)  sepby(reporting_year)
+	}
 		
+	else {
+		if ("`aggregate'" == "") {
+			sort country_code reporting_year region_code 
+			noi list country_code reporting_year poverty_line headcount mean median welfare_type /*
+			*/ in 1/`n2disp',  abbreviate(12)  sepby(country_code)
+		}
 		else {
-			if ("`aggregate'" == "") {
-				sort countrycode year regioncode
-				noi list countrycode year povertyline headcount mean median datatype /*
-				*/ in 1/`n2disp',  abbreviate(12)  sepby(countrycode)
-			}
-			else {
-				sort year
-				noi list year povertyline headcount mean , /*
-				*/ abbreviate(12) sepby(povertyline)
-			}		
-		}
+			sort reporting_year 
+			noi list reporting_year poverty_line headcount mean , /*
+			*/ abbreviate(12) sepby(poverty_line)
+		}		
 	}	
-	else { 
-		if ("`subcommand'" == "wb") {
-			sort reporting_year region_code 
-			noi list region reporting_year poverty_line headcount mean in 1/`n2disp', /*
-			*/ abbreviate(12)  sepby(reporting_year)
-		}
 		
-		else {
-			if ("`aggregate'" == "") {
-				sort country_code reporting_year region_code 
-				noi list country_code reporting_year poverty_line headcount mean median welfare_type /*
-				*/ in 1/`n2disp',  abbreviate(12)  sepby(country_code)
-			}
-			else {
-				sort reporting_year 
-				noi list reporting_year poverty_line headcount mean , /*
-				*/ abbreviate(12) sepby(poverty_line)
-			}		
-		}	
-	}	
-	
-
 	//========================================================
 	//  Create notes
 	//========================================================
@@ -608,10 +589,10 @@ qui {
 	//========================================================
 	// Convert to povcalnet format
 	//========================================================
-	/*
+	
 	if ("`povcalnet_format'" != "") {
 	  pip_povcalnet_format  `rtype', `pause'
-	} */
+	}
 	
 } // end of qui
 end

--- a/pip_cl.ado
+++ b/pip_cl.ado
@@ -25,7 +25,6 @@ syntax , [                       ///
            pause                 /// 
            iso                   /// 
            noDIPSQuery           /// 
-		   POVCALNET_format      ///
          ]
 
 version 11.0
@@ -170,16 +169,6 @@ foreach ict of local countries {
 
 local kquery : subinstr  local kquery  "|" " "
 keep if `kquery'
-
-/*==================================================
-            3:  Clean data
-==================================================*/
-	if ("`povcalnet_format'" != "") {
-		pip_povcalnet_format 1, year("`year'") `iso' rc(`rc')	
-	}
-	else { 
-		pip_clean 1, year("`year'") `iso' rc(`rc')		
-	}
 
 }
 end

--- a/pip_info.ado
+++ b/pip_info.ado
@@ -144,14 +144,7 @@ qui {
 			local current_line = 0
 			foreach cccc of local countries{
 				local current_line = `current_line' + 1 
-				
-				if ("`povcalnet_format'" != "") {
-					local display_this = "{stata pip_info, country(`cccc') clear povcalnet : `cccc'} "
-				} 
-				else {
-				    local display_this = "{stata pip_info, country(`cccc') clear : `cccc'} "
-				}				
-	
+				local display_this = "{stata pip_info, country(`cccc') clear: `cccc'} "
 				if (`current_line' < 10) noi display in y `"`display_this'"' _continue 
 				else{
 					noi display in y `"`display_this'"' 
@@ -164,22 +157,11 @@ qui {
 			
 			foreach i_reg of local regions{
 				local current_line = 0
-				if ("`povcalnet_format'" != "") {
-					local dipsthis "{stata  pip, region(`i_reg') year(all) aggregate povcalnet clear:`i_reg' }"
-				} 
-				else {
-				    local dipsthis "{stata  pip, region(`i_reg') year(all) aggregate clear:`i_reg' }"
-				}	
+				local dipsthis "{stata  pip, region(`i_reg') year(all) aggregate clear:`i_reg' }"
 				noi disp " `dipsthis' " _c
 			}
 			
-			if ("`povcalnet_format'" != "") {
-				noi display in y _n "{stata pip_info, region povcalnet povcalnet clear: World Bank regions by year}"
-			} 
-			else {
-				noi display in y _n "{stata pip_info, region clear: World Bank regions by year}"
-			}
-				
+			noi display in y _n "{stata pip_info, region clear: World Bank regions by year}"		
 			noi display _n ""
 			exit
 		}
@@ -214,14 +196,7 @@ qui {
 				foreach ind_y of local years_current {
 					local current_line = `current_line' + 1 
 					local ind_y_c=substr("`ind_y'",1,4)
-					if ("`povcalnet_format'" != "") {
-					    local display_this = "{stata  pip, country(`country') year(`ind_y') coverage(`coverage') povcalnet clear: `ind_y_c'}"
-					} 
-					else {
-						local display_this = "{stata  pip, country(`country') year(`ind_y') coverage(`coverage') clear: `ind_y_c'}"
-					}	
-				
-							
+					local display_this = "{stata  pip, country(`country') year(`ind_y') coverage(`coverage')   clear: `ind_y_c'}"		
 					if (`current_line' < 10) noi display in y `"`display_this'"' _continue 
 					else{
 						noi display in y `"`display_this'"' 
@@ -229,13 +204,7 @@ qui {
 					}
 				}	
 				
-				if ("`povcalnet_format'" != "") {
-				    noi display `"{stata  pip, country(`country') year(all) coverage(`coverage') povcalnet clear: All}"'
-				} 
-				else {
-					noi display `"{stata  pip, country(`country') year(all) coverage(`coverage')  clear: All}"'
-				}
-				
+				noi display `"{stata  pip, country(`country') year(all) coverage(`coverage')  clear: All}"'
 			}
 			restore
 			noi display _n ""
@@ -260,27 +229,14 @@ qui {
 				local years_current = "$refyears"
 				foreach ind_y of local years_current {
 					local current_line = `current_line' + 1 
-					if ("`povcalnet_format'" != "") {
-						local display_this = "{stata  pip, region(`i_reg') year(`ind_y') aggregate povcalnet clear: `ind_y'}"	
-					} 
-					else {
-						local display_this = "{stata  pip, region(`i_reg') year(`ind_y') aggregate clear: `ind_y'}"	
-					}
-						
+					local display_this = "{stata  pip, region(`i_reg') year(`ind_y') aggregate clear: `ind_y'}"		
 					if (`current_line' < 10) noi display in y `"`display_this'"' _continue 
 					else{
 						noi display in y `"`display_this'"' 
 						local current_line = 0		
 					}
 				}
-				if ("`povcalnet_format'" != "") {
-					noi display in y "{stata  pip, region(`i_reg') year(all) aggregate povcalnet clear: All}"
-				} 
-				else {
-					noi display in y "{stata  pip, region(`i_reg') year(all) aggregate clear: All}"
-				}
-								
-								
+				noi display in y "{stata  pip, region(`i_reg') year(all) aggregate clear: All}"				
 			}
 			noi display _n ""
 			exit

--- a/pip_povcalnet_format.ado
+++ b/pip_povcalnet_format.ado
@@ -16,21 +16,16 @@ Output:
 0: Program set up
 ==================================================*/
 program define pip_povcalnet_format, rclass
-
-version 16.0
-syntax anything(name=type),      ///
-             [                   ///
-								year(string)     ///
-								region(string)   ///
-								iso              ///
-								wb				///
-								nocensor			///
-								rc(string)       ///
-								pause			///
-             ]
+syntax [anything(name=type)]  ///
+[,                             	/// 
+pause                           /// 
+] 
 
 if ("`pause'" == "pause") pause on
-else                      pause off                      
+else                      pause off
+
+version 16.1
+
 
 noi disp in red "Warning: " in yellow /// 
 "option {it:povcalnet_format} is intended only to " _n ///
@@ -40,28 +35,16 @@ noi disp in red "Warning: " in yellow ///
 /*==================================================
 1:  country data 
 ==================================================*/
-
+ren reporting_year requestyear
+ren reporting_pop reqyearpopulation
 if ("`type'" == "1") {
-
-	if  ("`year'" == "last"){
-		bys country_code: egen maximum_y = max(reporting_year)
-		keep if maximum_y ==  reporting_year
-		drop maximum_y
-	}
-
-	pause check rename option 1
 	
-	***************************************************
-	* 5. Labeling/cleaning
-	***************************************************
-	gen countryname = ""
-	
-	local vars1 country_code region_code survey_coverage reporting_year survey_year /*
+	local vars1 country_code region_code survey_coverage survey_year /*
 	*/welfare_type is_interpolated distribution_type poverty_line poverty_gap /*
-	*/poverty_severity reporting_pop
+	*/poverty_severity // reporting_pop
 	
-	local vars2 countrycode regioncode coveragetype year datayear datatype isinterpolated usemicrodata /*
-	*/povertyline povgap povgapsqr population
+	local vars2 countrycode regioncode coveragetype datayear datatype isinterpolated usemicrodata /*
+	*/povertyline povgap povgapsqr //population
 	
 	local i = 0
 	foreach var of local vars1 {
@@ -69,80 +52,34 @@ if ("`type'" == "1") {
 		rename `var' `: word `i' of `vars2''
 	}	
 	
-	keep countrycode countryname regioncode coveragetype year datayear datatype isinterpolated usemicrodata /*
-	*/ ppp povertyline mean headcount povgap povgapsqr watts gini median mld polarization population decile? decile10
+	keep countrycode countryname regioncode coveragetype requestyear /* 
+	 */datayear datatype isinterpolated usemicrodata /*
+   */ ppp povertyline mean headcount povgap povgapsqr watts gini /* 
+	 */ median mld polarization reqyearpopulation decile? decile10
 	
-	order countrycode countryname regioncode coveragetype year datayear datatype isinterpolated usemicrodata /*
-	*/ ppp povertyline mean headcount povgap povgapsqr watts gini median mld polarization population decile? decile10
+	order countrycode countryname regioncode coveragetype requestyear /* 
+  */	datayear datatype isinterpolated usemicrodata /*
+	*/ ppp povertyline mean headcount povgap povgapsqr watts gini /* 
+  s*/	median mld polarization reqyearpopulation decile? decile10
 	
-	if "`iso'"!="" {
-		cap replace countrycode="XKX" if countrycode=="KSV"
-		cap replace countrycode="TLS" if countrycode=="TMP"
-		cap replace countrycode="PSE" if countrycode=="WBG"
-		cap replace countrycode="COD" if countrycode=="ZAR"
+	
+	* Standardize names with R package	
+	local Snames requestyear reqyearpopulation 
+	
+	local Rnames year population 
+	
+	local i = 0
+	foreach var of local Snames {
+		local ++i
+		rename `var' `: word `i' of `Rnames''
 	}
-
-	*rename  prmld  mld
-	foreach v of varlist polarization median gini mld decile? decile10 {
-		qui cap replace `v'=. if `v'==-1 | `v' == 0
-	}
-
-	cap drop if ppp==""
-	cap drop  svyinfoid
 	
-	pause query - after replacing invalid values to missing values
+	sort countrycode year coveragetype
 	
-	* cap drop  polarization
-	qui count
-	local obs=`r(N)'
-	
-	tostring coveragetype, replace
-	
-	replace coveragetype = "1" if coveragetype == "rural"
-	replace coveragetype = "2" if coveragetype == "urban"
-	replace coveragetype = "4" if coveragetype == "A" // not available in pip data
-	replace coveragetype = "3" if coveragetype == "national"
-	destring coveragetype, force replace
-	label define coveragetype 1 "Rural"     /* 
-	 */                       2 "Urban"     /* 
-	 */                       3 "National"  /* 
-	 */                       4 "National (Aggregate)", modify
-	 
-	label values coveragetype coveragetype
-
-	replace datatype = "1" if datatype == "consumption"
-	replace datatype = "2" if datatype == "income"
-	destring datatype, force replace
-	label define datatype 1 "Consumption" 2 "Income", modify
-	label values datatype datatype
-
-	label var isinterpolated    "Data is interpolated"
-	label var countrycode       "Country/Economy Code"
-	label var usemicrodata      "Data comes from grouped or microdata"
-	label var countryname       "Country/Economy Name"
-	label var regioncode        "Region Code"
-	label var region            "Region Name"
-	label var coveragetype      "Coverage"
-	label var year              "Year you requested"
-	label var datayear          "Survey year"
-	label var datatype          "Welfare measured by income or consumption"
-	label var ppp               "Purchasing Power Parity"
-	label var povertyline       "Poverty line in PPP$ (per capita per day)"
-	label var mean              "Average monthly per capita income/consumption in PPP$"
-	label var headcount         "Poverty Headcount"
-	label var povgap            "Poverty Gap."
-	label var povgapsqr         "Squared poverty gap."
-	label var watts             "Watts index"
-	label var gini              "Gini index"
-	label var median            "Median monthly income or expenditure in PPP$"
-	label var mld               "Mean Log Deviation"
-	label var population        "Population in year"
-
 	//------------ Convert to monthly values
 	replace mean = mean * (360/12)
 	replace median = median * (360/12)
 
-	sort countrycode year coveragetype
 }
 
 /*==================================================
@@ -157,10 +94,10 @@ if ("`type'" == "2") {
 	rename poverty_gap povgap
 	rename poverty_severity povgapsqr
 	
-	keep reporting_year regioncode povertyline mean headcount povgap povgapsqr reporting_pop
-	order reporting_year regioncode povertyline mean headcount povgap povgapsqr reporting_pop
+	keep requestyear regioncode povertyline mean headcount povgap povgapsqr reqyearpopulation
+	order requestyear regioncode povertyline mean headcount povgap povgapsqr reqyearpopulation
 	
-	local Snames reporting_year reporting_pop 
+	local Snames requestyear reqyearpopulation 
 	
 	local Rnames year population 
 	
@@ -170,16 +107,7 @@ if ("`type'" == "2") {
 		rename `var' `: word `i' of `Rnames''
 	}
 	
-	label var year              "Year you requested"
-	label var regioncode        "Region code"
-	label var povertyline       "Poverty line in PPP$ (per capita per day)"
-	label var mean              "Average monthly per capita income/consumption in PPP$"
-	label var headcount         "Poverty Headcount"
-	label var povgap            "Poverty Gap"
-	label var povgapsqr         "Squared poverty gap"
-	label var population        "Population in year"
 	//------------ Convert to monthly values
-	
 	replace mean = mean * (360/12)
 	
 } // end of type 2


### PR DESCRIPTION
Hi Andres,

I have made few changes to the ado files per our discussion (regarding povcalnet_format). All the ado files works in generating the povcalnet_format option except pip_info. Curretly, the pip_info.ado (clickable option) works only for PIP data structure format. I am trying to see how we can also get the result in povcalnet_format.

Best,
Tefera