### PR TITLE
Update api handel in pip_cl ado file, and other updates

### DIFF
--- a/pip.ado
+++ b/pip.ado
@@ -296,14 +296,14 @@ qui {
 		povline("`povline'")             ///
 		ppp("`ppp'")                     ///
 		server("`server'")               ///
-		server("`handle'")               ///
+		handle("`handle'")               ///
 		coverage(`coverage')             /// 
 		`clear'                          ///
 		`iso'                            ///
 		`pause'
 		return add
 		
-		pip_clean 1, year("`year'") `iso' rc(`rc')
+		pip_clean 1, year("`year'") `iso' //rc(`rc')
 		
 		//========================================================
 		// Convert to povcalnet format

--- a/pip_cl.ado
+++ b/pip_cl.ado
@@ -49,6 +49,8 @@ if ("`coverage'" == "") local coverage -1
 *---------- download guidance data
 pip_info, clear justdata `pause'
 
+cwf _pip_lkup
+
 levelsof country_code, local(countries) clean
 if (lower("`country'") != "all") {
 

--- a/pip_clean.ado
+++ b/pip_clean.ado
@@ -47,7 +47,44 @@ if ("`type'" == "1") {
 	***************************************************
 	* 5. Labeling/cleaning
 	***************************************************
-	gen countryname = ""
+	// check if country data frame is available
+	
+	frame dir 
+	local av_frames "`r(frames)'"
+	local av_frames: subinstr local  av_frames " " "|", all
+	local av_frames = "^(" + "`av_frames'" + ")"
+	
+	//------------ countries frame
+	local frpipcts "_pip_countries"
+	if (!regexm("`frpipcts'", "`av_frames'")) {
+		
+		frame create `frpipcts'
+		
+		frame `frpipcts' {
+			
+			local csvfile0  = "`url'/aux?table=countries&format=csv"
+			cap import delimited using "`csvfile0'", clear varn(1)
+			
+			if (_rc != 0 ) {
+				noi disp in red "There is a problem accessing country name data." 
+				noi disp in red "to check your connection, copy and paste in your browser the following address:" _n /* 
+				*/	_col(4) in w `"`csvfile0'"'
+				
+				error 
+			} 
+			
+			drop iso2_code
+			sort country_code
+		}
+		
+	}
+	
+	frlink m:1 country_code, frame(_pip_countries) generate(ctry_name)
+	frget country_name, from(ctry_name)
+	
+	drop ctry_name
+	
+	rename country_name countryname
 	
 	order country_code countryname region_code survey_coverage reporting_year survey_year welfare_type is_interpolated distribution_type /*
 	*/ ppp poverty_line mean headcount poverty_gap poverty_severity watts gini median mld polarization reporting_pop decile? decile10

--- a/pip_set_server.ado
+++ b/pip_set_server.ado
@@ -72,7 +72,7 @@ if (!regexm(tpage, "API is running") | _rc) {
 }
 
 local url     = "`server'/`handle'"	
-local url2    = "http://wzlxqpip01.worldbank.org/`handle'"
+local url2    = "http://wzlxqpip01.worldbank.org/api/v1"
 
 
 //========================================================


### PR DESCRIPTION
Hi Andres,

I have updated the following 	pip.ado, pip_cl.ado,  pip_clean.ado, pip_info.ado and pip_set_server.ado.

I noticed that api endpoint (http://wzlxqpip01.worldbank.org/pip/v1/pip-grp) that is being used to get regional aggregate query data doesn't work. For example if query pip, region(MNA) year(all) aggregate clear, it returns aggregate data for all regions not specifically MNA.  It same if we query aggregate data by other regions like LAC or EAP.

For example all this three query returned same result.
pip, region(MNA) year(all) aggregate clear
pip, region(EAP) year(all) aggregate clear
pip, region(LAC) year(all) aggregate clear

import delimited "http://wzlxqpip01.worldbank.org/pip/v1/pip-grp?year=all&country=all&reporting_level=all&povline=1.9&group_by=none&format=csv", clear varn(1)

In the above code, the group_by parameter doesn't accept region code, it always returns none (which means generate all regions).

Best,
Tefera
 