### PR TITLE
Repace reporting_year variable with surveyid_year in pip_query.ado

### DIFF
--- a/pip.ado
+++ b/pip.ado
@@ -169,6 +169,14 @@ qui {
 	}
 	
 	if ("`year'" == "") local year "all"
+	if ("`year'" != "" & "`year'" != "all"){
+		local yrtemp
+		foreach yr of local year {
+			local tt = substr("`yr'", 1, 4) 
+			local yrtemp `yrtemp' `tt'
+		}
+		local year "`yrtemp'"
+	} 
 	* 
 	
 	*---------- Coverage

--- a/pip_query.ado
+++ b/pip_query.ado
@@ -56,7 +56,7 @@ quietly {
 	if ("`year'" != "all" & ("`wb'" != "" | "`aggregate'" != "")) {	
 		
 		
-		frame `frpipim': levelsof reporting_year, local(ref_years_l)
+		frame `frpipim': levelsof surveyid_year, local(ref_years_l)
 		local ref_years "`ref_years_l' last"
 		
 		local no_ref: list year - ref_years
@@ -147,7 +147,7 @@ quietly {
 				foreach ct of local cts {
 					
 					count if country_code == "`ct'" & ///
-					      regexm(strofreal(reporting_year), "`years_'") & `touse'
+					      regexm(strofreal(surveyid_year), "`years_'") & `touse'
 								
 					local year_ok =  r(N)
 					


### PR DESCRIPTION
Hi Cathrine,

I noticed that the api endpoint uses surveyid_year information to query estimate, so I have replace reporting_year variable with surveyid_year variable in pip_query.ado. This will resolve one of the issue Daniel has raised.

Best,
Tefera